### PR TITLE
Add unique connection identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+- Add `Connection#sid`, a unique connection identifier.
+
 - Add `Connection#broadcast` as an interface for broadcasting from channels.
 
 - Add `config.fastlane_broadcasts_enabled` to opt-in for optimized broadcasts (no double JSON encoding).

--- a/lib/action_cable/connection/base.rb
+++ b/lib/action_cable/connection/base.rb
@@ -59,7 +59,7 @@ module ActionCable
       include Callbacks
       include ActiveSupport::Rescuable
 
-      attr_reader :subscriptions, :logger
+      attr_reader :subscriptions, :logger, :sid
       private attr_reader :server, :socket
 
       delegate :pubsub, :executor, :config, :broadcast, to: :server
@@ -68,6 +68,8 @@ module ActionCable
       def initialize(server, socket)
         @server = server
         @socket = socket
+        # unique session identifier (obtained from the request_id by default)
+        @sid = socket.try(:request_id) || SecureRandom.uuid
 
         @logger = socket.logger
         @subscriptions  = Subscriptions.new(self)

--- a/lib/action_cable/server/connections.rb
+++ b/lib/action_cable/server/connections.rb
@@ -13,16 +13,18 @@ module ActionCable
     module Connections # :nodoc:
       BEAT_INTERVAL = 3
 
-      def connections
-        @connections ||= []
+      def connections_map
+        @connections_map ||= {}
       end
 
+      def connections = connections_map.values
+
       def add_connection(connection)
-        connections << connection
+        connections_map[connection.sid] = connection
       end
 
       def remove_connection(connection)
-        connections.delete connection
+        connections_map.delete connection.sid
       end
 
       # WebSocket connection implementations differ on when they'll mark a connection
@@ -32,12 +34,12 @@ module ActionCable
       # disconnect.
       def setup_heartbeat_timer
         @heartbeat_timer ||= executor.timer(BEAT_INTERVAL) do
-          executor.post { connections.each(&:beat) }
+          executor.post { connections_map.each_value(&:beat) }
         end
       end
 
       def open_connections_statistics
-        connections.map(&:statistics)
+        connections_map.each_value.map(&:statistics)
       end
     end
   end

--- a/lib/action_cable/server/socket.rb
+++ b/lib/action_cable/server/socket.rb
@@ -9,7 +9,7 @@ module ActionCable
     # This connection object is also responsible for handling encoding and decoding of messages, so the user-level
     # connection object shouldn't know about such details.
     class Socket
-      attr_reader :server, :env, :protocol, :logger, :connection
+      attr_reader :server, :env, :protocol, :logger, :connection, :request_id
       private attr_reader :worker_pool
 
       delegate :event_loop, :pubsub, :config, to: :server
@@ -24,6 +24,7 @@ module ActionCable
         @message_buffer = MessageBuffer.new(self)
 
         @protocol = nil
+        @request_id = env["action_dispatch.request_id"] || env["HTTP_X_REQUEST_ID"]
         @connection = config.connection_class.call.new(server, self)
       end
 

--- a/test/server/base_test.rb
+++ b/test/server/base_test.rb
@@ -11,6 +11,12 @@ class BaseTest < ActionCable::TestCase
   end
 
   class FakeConnection
+    attr_reader :sid
+
+    def initialize
+      @sid = SecureRandom.hex(3)
+    end
+
     def close
     end
   end

--- a/test/server/socket/client_socket_test.rb
+++ b/test/server/socket/client_socket_test.rb
@@ -6,8 +6,11 @@ require "stubs/test_server"
 class ActionCable::Server::Socket::ClientSocketTest < ActionCable::TestCase
   class TestSocket < ActionCable::Server::Socket
     class TestConnection
+      attr_reader :sid
+
       def initialize(socket)
         @socket = socket
+        @sid = socket.request_id
       end
 
       def handle_open = @socket.connect
@@ -74,7 +77,8 @@ class ActionCable::Server::Socket::ClientSocketTest < ActionCable::TestCase
     def open_connection
       env = Rack::MockRequest.env_for "/test",
         "HTTP_CONNECTION" => "upgrade", "HTTP_UPGRADE" => "websocket",
-        "HTTP_HOST" => "localhost", "HTTP_ORIGIN" => "http://rubyonrails.com"
+        "HTTP_HOST" => "localhost", "HTTP_ORIGIN" => "http://rubyonrails.com",
+        "HTTP_X_REQUEST_ID" => SecureRandom.uuid
       io, client_io = \
         begin
           Socket.pair(Socket::AF_UNIX, Socket::SOCK_STREAM, 0)

--- a/test/server/socket/stream_test.rb
+++ b/test/server/socket/stream_test.rb
@@ -7,8 +7,11 @@ require "stubs/test_server"
 class ActionCable::Server::Socket::StreamTest < ActionCable::TestCase
   class TestSocket < ActionCable::Server::Socket
     class TestConnection
+      attr_reader :sid
+
       def initialize(socket)
         @socket = socket
+        @sid = socket.request_id
       end
 
       def handle_open = @socket.connect
@@ -64,7 +67,8 @@ class ActionCable::Server::Socket::StreamTest < ActionCable::TestCase
     def open_connection(io)
       env = Rack::MockRequest.env_for "/test",
         "HTTP_CONNECTION" => "upgrade", "HTTP_UPGRADE" => "websocket",
-        "HTTP_HOST" => "localhost", "HTTP_ORIGIN" => "http://rubyonrails.com"
+        "HTTP_HOST" => "localhost", "HTTP_ORIGIN" => "http://rubyonrails.com",
+        "action_dispatch.request_id" => SecureRandom.uuid
       env["rack.hijack"] = -> { env["rack.hijack_io"] = io }
 
       TestSocket.new(@server, env).tap do |socket|

--- a/test/server/socket_test.rb
+++ b/test/server/socket_test.rb
@@ -6,10 +6,11 @@ require "active_support/core_ext/object/json"
 
 class ActionCable::Server::SocketTest < ActionCable::TestCase
   class Connection
-    attr_reader :last_message, :socket, :connected
+    attr_reader :last_message, :socket, :connected, :sid
 
     def initialize(_server, socket)
       @socket = socket
+      @sid = SecureRandom.hex(3)
     end
 
     def handle_open


### PR DESCRIPTION
## Context

This PR adds unique connection identifiers to connections. The primary reason is to migrate the connections list to Hash for faster deletion (see #4), but this feature could be also used for tracing (since IDs are inferred from request IDs where available).

Closes #4