### PR TITLE
Add missing `super`

### DIFF
--- a/lib/action_cable/connection/subscriptions.rb
+++ b/lib/action_cable/connection/subscriptions.rb
@@ -40,7 +40,7 @@ module ActionCable
 
       class UnknownSubscription < Error
         def initialize(identifier)
-          "Unable to find subscription with identifier: #{identifier}"
+          super "Unable to find subscription with identifier: #{identifier}"
         end
       end
 


### PR DESCRIPTION
Adds a missing `super` to the `UnknownSubscription` exception.