### PR TITLE
Fix test server timer shutdown

### DIFF
--- a/lib/action_cable/channel/test_case.rb
+++ b/lib/action_cable/channel/test_case.rb
@@ -238,6 +238,15 @@ module ActionCable
           subscription.perform_action(data.stringify_keys.merge("action" => action.to_s))
         end
 
+        # Advance the virtual clock used by `periodically` timers.
+        #
+        #     subscribe
+        #     advance_time 5.seconds
+        #     assert_equal 1, subscription.tick_count
+        def advance_time(seconds)
+          testserver.advance_time(seconds)
+        end
+
         # Returns messages transmitted into channel
         def transmissions
           # Return only directly sent message (via #transmit)

--- a/lib/action_cable/connection/test_case.rb
+++ b/lib/action_cable/connection/test_case.rb
@@ -102,6 +102,10 @@ module ActionCable
       end
     end
 
+    class TestTimer
+      def shutdown; end
+    end
+
     # TestServer provides test pub/sub and executor implementations
     class TestServer
       attr_reader :streams, :config
@@ -118,8 +122,7 @@ module ActionCable
 
       # Inline async calls
       def post(&work) = work.call
-      # We don't support timers in unit tests yet
-      def timer(_every) = nil
+      def timer(_every) = TestTimer.new
 
       #== Pub/sub interface ==
       def subscribe(stream, callback, success_callback = nil)

--- a/lib/action_cable/connection/test_case.rb
+++ b/lib/action_cable/connection/test_case.rb
@@ -100,19 +100,44 @@ module ActionCable
       def close
         @closed = true
       end
+
+      def perform_work(receiver, method_name, *args)
+        receiver.public_send(method_name, *args)
+      end
     end
 
     class TestTimer
-      def shutdown; end
+      attr_reader :interval
+
+      def initialize(interval, &block)
+        @interval = interval
+        @block = block
+        @elapsed = 0
+        @shutdown = false
+      end
+
+      def shutdown
+        @shutdown = true
+      end
+
+      def advance(seconds)
+        return if @shutdown
+        @elapsed += seconds
+        while @elapsed >= @interval
+          @elapsed -= @interval
+          @block&.call
+        end
+      end
     end
 
     # TestServer provides test pub/sub and executor implementations
     class TestServer
-      attr_reader :streams, :config
+      attr_reader :streams, :config, :timers
 
       def initialize(server)
         @streams = Hash.new { |h, k| h[k] = [] }
         @config = server.config
+        @timers = []
       end
 
       alias_method :pubsub, :itself
@@ -122,7 +147,14 @@ module ActionCable
 
       # Inline async calls
       def post(&work) = work.call
-      def timer(_every) = TestTimer.new
+
+      def timer(every, &block)
+        TestTimer.new(every, &block).tap { |t| @timers << t }
+      end
+
+      def advance_time(seconds)
+        @timers.each { |timer| timer.advance(seconds) }
+      end
 
       #== Pub/sub interface ==
       def subscribe(stream, callback, success_callback = nil)

--- a/test/channel/test_case_test.rb
+++ b/test/channel/test_case_test.rb
@@ -95,6 +95,26 @@ class RejectionTestChannelTest < ActionCable::Channel::TestCase
   end
 end
 
+class RejectingPeriodicTimerChannel < ActionCable::Channel::Base
+  periodically :tick, every: 1
+
+  def subscribed
+    reject
+  end
+
+  private
+    def tick; end
+end
+
+class RejectingPeriodicTimerChannelTest < ActionCable::Channel::TestCase
+  tests RejectingPeriodicTimerChannel
+
+  def test_reject_does_not_crash_when_periodic_timer_is_registered
+    assert_nothing_raised { subscribe }
+    assert_predicate subscription, :rejected?
+  end
+end
+
 class StreamsTestChannel < ActionCable::Channel::Base
   def subscribed
     stream_from "test_#{params[:id] || 0}"

--- a/test/channel/test_case_test.rb
+++ b/test/channel/test_case_test.rb
@@ -115,6 +115,49 @@ class RejectingPeriodicTimerChannelTest < ActionCable::Channel::TestCase
   end
 end
 
+class PeriodicCounterChannel < ActionCable::Channel::Base
+  periodically :tick, every: 5
+
+  attr_reader :tick_count
+
+  def subscribed
+    @tick_count = 0
+  end
+
+  private
+    def tick
+      @tick_count += 1
+    end
+end
+
+class PeriodicCounterChannelTest < ActionCable::Channel::TestCase
+  tests PeriodicCounterChannel
+
+  def test_advance_time_fires_periodic_callback_when_interval_is_reached
+    subscribe
+    assert_equal 0, subscription.tick_count
+
+    advance_time 4
+    assert_equal 0, subscription.tick_count
+
+    advance_time 1
+    assert_equal 1, subscription.tick_count
+
+    advance_time 12
+    assert_equal 3, subscription.tick_count
+  end
+
+  def test_shutdown_timer_stops_firing_after_unsubscribe
+    subscribe
+    advance_time 5
+    assert_equal 1, subscription.tick_count
+
+    unsubscribe
+    advance_time 100
+    assert_equal 1, subscription.tick_count
+  end
+end
+
 class StreamsTestChannel < ActionCable::Channel::Base
   def subscribed
     stream_from "test_#{params[:id] || 0}"


### PR DESCRIPTION
When upgrading our Rails app to Falcon + async-cable I hit this on a channel in our app that declares periodically and rejects under some param combinations.

A rejecting subscribe ran into `NoMethodError: undefined method 'shutdown' for nil` from `Channel::PeriodicTimers#stop_periodic_timers`. `TestServer#timer` returns nil, but the channel's teardown then calls `shutdown` on every registered timer and… well nil doesn't respond to it =)

First commit returns a no-op TestTimer instead, so periodic channels can roundtrip through subscribe and unsubscribe in tests without crashing.

The second commit adds some sugar on top: the no-op timer becomes a TestTimer that records its interval and block, and a new `advance_time(seconds)` helper on `Channel::TestCase` and `TestServer` fires registered timers once per full interval reached. This would let tests assert on periodically behavior deterministically without a real clock.

```ruby
  class CounterChannel < ApplicationCable::Channel
    periodically :tick, every: 5
    # ...
  end

  class CounterChannelTest < ActionCable::Channel::TestCase
    def test_periodic
      subscribe
      assert_equal 1, subscription.tick_count
      advance_time 6.seconds
      assert_equal 2, subscription.tick_count
    end
  end
```

Note that I didn't really have this requirement so it might be a bit contrived 🤷 

Each commit should be independently reviewable, take only the first if the helper feels out of scope.