### PR TITLE
Wrap Connection :command callback with executor

### DIFF
--- a/lib/action_cable/engine.rb
+++ b/lib/action_cable/engine.rb
@@ -102,6 +102,13 @@ module ActionCable
         ActionCable::Channel::Base.set_callback :subscribe, :around, prepend: true, &wrap
         ActionCable::Channel::Base.set_callback :unsubscribe, :around, prepend: true, &wrap
       end
+
+      ActiveSupport.on_load(:action_cable_connection) do
+        wrap = lambda do |_, inner|
+          app.executor.wrap(source: "application.action_cable", &inner)
+        end
+        ActionCable::Connection::Base.set_callback :command, :around, prepend: true, &wrap
+      end
     end
 
     config.after_initialize do

--- a/test/connection/executor_wrap_test.rb
+++ b/test/connection/executor_wrap_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "stubs/test_server"
+
+class ActionCable::Connection::ExecutorWrapTest < ActionCable::TestCase
+  class FakeExecutor
+    attr_reader :wrap_calls
+
+    def initialize
+      @wrap_calls = []
+    end
+
+    def wrap(source: nil)
+      @wrap_calls << source
+      yield
+    end
+  end
+
+  class Connection < ActionCable::Connection::Base
+    cattr_accessor :test_executor
+
+    around_command do |_, inner|
+      test_executor.wrap(source: "application.action_cable", &inner)
+    end
+  end
+
+  class ChatChannel < ActionCable::Channel::Base
+    class << self
+      attr_accessor :subscribed_count
+    end
+
+    self.subscribed_count = 0
+
+    def subscribed
+      self.class.subscribed_count += 1
+    end
+  end
+
+  setup do
+    Connection.test_executor = FakeExecutor.new
+    ChatChannel.subscribed_count = 0
+
+    @server = TestServer.new
+    @env = Rack::MockRequest.env_for "/test", "HTTP_HOST" => "localhost", "HTTP_CONNECTION" => "upgrade", "HTTP_UPGRADE" => "websocket"
+
+    @socket = ActionCable::Server::Socket.new(@server, @env)
+    @connection = Connection.new(@server, @socket)
+    @identifier = { channel: "ActionCable::Connection::ExecutorWrapTest::ChatChannel" }.to_json
+  end
+
+  attr_reader :server, :env, :connection, :identifier
+
+  test "handle_channel_command runs inside executor.wrap" do
+    connection.handle_channel_command({ "identifier" => identifier, "command" => "subscribe" })
+
+    assert_equal ["application.action_cable"], Connection.test_executor.wrap_calls
+    assert_equal 1, ChatChannel.subscribed_count
+  end
+end


### PR DESCRIPTION
This one I am a bit less sure about since it does not relate to any observed behaviour on my part but just something I saw when spelunking the code. https://github.com/rails/rails/pull/23807 adds an execution wrapper around ”`:work`” which I _think_ is missing here and would be the `:command`?.

If this is a concious decision then sorry about the noise. Was unable to figure that out from looking at the history.

### Details

`ActionCable::Connection::Base#handle_channel_command` runs the `:command` callback chain inline. Under the stock Server::Socket the worker pool's `:work` callback wraps each dispatch with `app.executor.wrap`, but adapters that bypass the worker pool (e.g. async-cable's `Socket#perform_work`, which calls `receiver.send(...)` directly) lose that wrap.

Without it, command dispatch on those adapters runs outside the Rails executor. In production this means query cache and CurrentAttributes are not reset between commands, so state set via `Current.set(...)` in one handler leaks into the next on the same connection. In development the reloader can acquire :unload while dispatch is mid-flight, since no share is held to gate it.

Mirror the :subscribe/:unsubscribe wrap on `Channel::Base` so the wrap fires at the connection layer too, independent of the adapter's dispatch mechanism. Should be safe under re-entry: `ExecutionWrapper.wrap` is a no-op when the executor is already active, so the existing channel-level wrap becomes a fast-path no-op.

Tests assert that `handle_channel_command` runs inside the `executor.wrap` callback when an around_command wrap is registered, mirroring the engine hook in `lib/action_cable/engine.rb`.